### PR TITLE
feat: specify the port that instance registered to nacos

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,5 +8,6 @@ COPY *.jar /app.jar
 ENTRYPOINT ["java","-Djava.security.egd=file:/dev/./urandom","-jar","/app.jar",\
             "--suffix.num=${SUFFIX_NUM}","--spring.cloud.nacos.discovery.server-addr=${NACOS_ADDR}",\
             "--spring.application.name=${SERVICE_NAME}","--spring.cloud.nacos.discovery.group=${GROUP}",\
-            "--spring.cloud.nacos.discovery.namespace=${NAMESPACE}"]
+            "--spring.cloud.nacos.discovery.namespace=${NAMESPACE}",\
+            "--spring.cloud.nacos.discovery.port=${DISCOVERY_PORT}"]
 EXPOSE 18001


### PR DESCRIPTION
specify the port that instance registered to nacos, so we can distinguish specific upstreams by port when test.

relate to: [`7d8c2a9` (#5083)](https://github.com/apache/apisix/pull/5083/commits/7d8c2a9794642c999fbe8cd47fa83004d25d24a5)

reference: https://github.com/alibaba/nacos/issues/310#issuecomment-542957993

I have verified.