### PR TITLE
feat: support specify the port that instance registered to nacos

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,9 +4,11 @@ ENV NACOS_ADDR=${NACOS_ADDR:-127.0.0.1:8848}
 ENV SERVICE_NAME=${SERVICE_NAME:-gateway-service}
 ENV NAMESPACE=${NAMESPACE}
 ENV GROUP=${GROUP:-DEFAULT_GROUP}
+ENV DISCOVERY_PORT=${DISCOVERY_PORT:-18001}
 COPY *.jar /app.jar
 ENTRYPOINT ["java","-Djava.security.egd=file:/dev/./urandom","-jar","/app.jar",\
             "--suffix.num=${SUFFIX_NUM}","--spring.cloud.nacos.discovery.server-addr=${NACOS_ADDR}",\
             "--spring.application.name=${SERVICE_NAME}","--spring.cloud.nacos.discovery.group=${GROUP}",\
-            "--spring.cloud.nacos.discovery.namespace=${NAMESPACE}"]
+            "--spring.cloud.nacos.discovery.namespace=${NAMESPACE}",\
+            "--spring.cloud.nacos.discovery.port=${DISCOVERY_PORT}"]
 EXPOSE 18001


### PR DESCRIPTION
support specify the port that instance registered to nacos, if not pass the env `DISCOVERY_PORT`, would use 18001 as default port to register.